### PR TITLE
Fix crash on Apple Silicon

### DIFF
--- a/Sources/LoginItemKit/LoginItemKit.swift
+++ b/Sources/LoginItemKit/LoginItemKit.swift
@@ -31,7 +31,7 @@ public struct LoginItemKit {
             
             if let itemList = LSSharedFileListCreate(nil, kLSSharedFileListSessionLoginItems.takeRetainedValue(), nil)?.takeRetainedValue() {
                     
-                LSSharedFileListInsertItemURL(itemList, kLSSharedFileListItemBeforeFirst.takeRetainedValue(), nil, nil, bundleURL, nil, nil)
+                LSSharedFileListInsertItemURL(itemList, nil, nil, nil, bundleURL, nil, nil)
 
             }
             


### PR DESCRIPTION
Removed `kLSSharedFileListItemBeforeFirst` as this somehow seems to crash on Apple Silicon.